### PR TITLE
fix variabile durata non visibile

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -109,8 +109,9 @@ let calcolateDuration(oraInizio,oraFine)={
   return  text(addZeroes(resultTimeHours)+":"+addZeroes(resultTimeMinutes));
 }
 
+let durata = ""
 if docType == "verbale"{
-  let durata = calcolateDuration(oraInizio,oraFine);
+  durata = calcolateDuration(oraInizio,oraFine);
 }
 
 //Capire se si tratta di un verbale per condizionare il layout


### PR DESCRIPTION
let durata era all'interno di un blocco if, non risultando visibile all'esterno e generando errore nelle linee successive.

Risolto ponendo let durata = "" prima del blocco if.

Link alla issue di Jira:
//

Note:

### ✏️ Checklist

- [x] documento testato;
- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.