### PR TITLE
DOC-98 Implementazione checklist di supporto nelle PR

### DIFF
--- a/.github/pull_request_review_guidance.md
+++ b/.github/pull_request_review_guidance.md
@@ -1,0 +1,15 @@
+🔬 Durante il processo di review, verificare che:
+- [ ] il messaggio di PR contenga i dati minimi richiesti;
+- [ ] il nome del file sia corretto;
+- [ ] il documento sia posizionato nella propria sottocartella;
+- [ ] il documento contenga il preambolo;
+- [ ] i parametri di configurazione siano correttamente impostati;
+  - [ ] la data sia indicata nel formato `aa-mm-yy` (es. 23-12-31);
+- [ ] il documento rispetti le norme stilistiche prestabilite;
+- [ ] le modifiche proposte dalla PR siano specifiche;
+
+✅ Al termine del processo di review, in caso di approvazione:
+- [ ] se la PR chiude uno o più ticket, menzionarli nel messaggio di chiusura;
+- [ ] unire (merge) e chiudere la PR.
+
+*Attenzione: le caselle di controllo sono soggette a reset automatico ogni qualvolta sia nuovamente richiesta la review.*

--- a/.github/workflows/comment_review_guidance.yml
+++ b/.github/workflows/comment_review_guidance.yml
@@ -1,0 +1,17 @@
+name: Comment PR with review guidance
+
+on: pull_request
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    name: Provide review guidance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Comment PR
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-path: .github/pull_request_review_guidance.md
+          allow-repeats: false


### PR DESCRIPTION
Questa automazione pubblica in ogni PR una checklist con l'obiettivo di aiutare il verificatore durante il processo di verifica.

Sarà sicuramente soggetta a modifiche in sincronia con l'estensione delle Norme di Progetto.

Qui sotto è presente un messaggio di esempio.

https://error418swe.atlassian.net/browse/DOC-98?atlOrigin=eyJpIjoiY2U4ZjE2ZjViYTU2NDk0NDk2MjkyOGRiNzc5NDEzNzciLCJwIjoiaiJ9