### PR TITLE
DOC-97 aggiungere UC rimanenti fino alla UC-6

### DIFF
--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -191,3 +191,23 @@ $bold("Scenario: ")$
 $bold("Estensioni: ")$
 UC-3.1 Visualizzazione errore di modifica dell'ambiente.
 
+
+
+
+=== UC-3.1 Visualizzazione errore di modifica dell'ambiente
+$bold("Descrizione: ")$ 
+i dati inseriti per la modifica dell'ambiente di lavoro non sono validi con quanto configurato precedentemente.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+- l'utente ha immesso i dati per la modifica dell'ambiente;
+- tali dati non sono congrui con la precedente configurazione dell'ambiente.
+
+$bold("Postcondizioni: ")$
+viene visualizzato il messaggio di errore relativo ad un'immissione errata dei dati per la modifica dell'ambiente.
+
+$bold("Scenario: ")$
+l'utente ha immesso dei dati errati per la modifica dell'ambiente.
+

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -147,7 +147,7 @@ $bold("Scenario: ")$
 l'utente inserisce i dati relativi alla configurazione.
 
 $bold("Estensioni: ")$
-UC 2.1 Visualizzazione errore sui dati.
+UC-2.1 Visualizzazione errore sui dati.
 
 
 
@@ -189,5 +189,5 @@ $bold("Scenario: ")$
 - l'utente immette i dati richiesti.
 
 $bold("Estensioni: ")$
-UC3.1 - Visualizzazione errore di modifica dell'ambiente.
+UC-3.1 Visualizzazione errore di modifica dell'ambiente.
 

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -148,3 +148,23 @@ l'utente inserisce i dati relativi alla configurazione.
 
 $bold("Estensioni: ")$
 UC 2.1 Visualizzazione errore sui dati.
+
+
+
+=== UC-2.1 Visualizzazione errore sui dati
+$bold("Descrizione: ")$
+i dati inseriti per la configurazione manuale dell'ambiente di lavoro non sono validi.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+- inseriti dati per la configurazione manuale dell'ambiente;
+- tali dati non sono utilizzabili dal programma.
+
+
+$bold("Postcondizioni: ")$
+viene visualizzato l'errore relativo all'inserimento di dati non validi.
+
+$bold("Scenario: ")$
+l'utente inserisce dati relativi alla configurazione dell'ambiente non validi.

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -275,3 +275,22 @@ $bold("Scenario: ")$
 - l'utente ha avviato la procedura di modifica di uno scaffale esistente;
 - l'utente ha immesso dati non validi o che comporterebbero incongruenze con i bin o altri elementi dell'ambiente.
 
+
+== UC-6 Eliminazione scaffale
+$bold("Descrizione: ")$ 
+uno scaffale presente nell'ambiente viene eliminato.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+nell'ambiente deve essere posizionato almeno uno scaffale.
+
+$bold("Postcondizioni: ")$
+- lo scaffale selezionato viene rimosso dall'ambiente;
+- vengono rimossi i bin in esso contenuti.
+
+$bold("Scenario: ")$
+- l'utente seleziona uno scaffale nell'ambiente;
+- l'utente seleziona il comando per la rimozione dello scaffale;
+- l'utente conferma l'operazione da una finestra di conferma.

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -231,3 +231,26 @@ $bold("Scenario: ")$
 - l'utente seleziona l'aggiunta di uno scaffale;
 - l'utente inserisce i dati necessari alla creazione di uno scaffale;
 - l'utente posiziona lo scaffale in una posiziona valida nell'ambiente.
+
+
+
+== UC-5 Modifica scaffale 
+$bold("Descrizione: ")$ 
+modifica dei valori di uno scaffale già esistente.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+nell'ambiente deve essere posizionato almeno uno scaffale.
+
+$bold("Postcondizioni: ")$
+i valori relativi ad uno scaffale sono stati modificati come indicato.
+
+$bold("Scenario: ")$
+- l'utente seleziona uno scaffale nell'ambiente;
+- l'utente seleziona il comando per la modifica dello scaffale;
+- l'utente inserisce i nuovi valori.
+
+$bold("Estensioni: ")$
+UC-5.1 Visualizzazione errore inserimento valori errati per la modifica di uno scaffale.

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -168,3 +168,26 @@ viene visualizzato l'errore relativo all'inserimento di dati non validi.
 
 $bold("Scenario: ")$
 l'utente inserisce dati relativi alla configurazione dell'ambiente non validi.
+
+
+
+== UC-3 Modifica ambiente 3d
+$bold("Descrizione: ")$ 
+il perimetro dell'ambiente di lavoro viene modificato successivamente alla sua configurazione iniziale.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+- almeno una configurazione dell'ambinete deve essere avvenuta con successo;
+
+$bold("Postcondizioni: ")$
+l'ambiente di lavoro è stato modificato con successo.
+
+$bold("Scenario: ")$
+- l'utente avvia la modifica dell'ambiente di lavoro;
+- l'utente immette i dati richiesti.
+
+$bold("Estensioni: ")$
+UC3.1 - Visualizzazione errore di modifica dell'ambiente.
+

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -211,3 +211,23 @@ viene visualizzato il messaggio di errore relativo ad un'immissione errata dei d
 $bold("Scenario: ")$
 l'utente ha immesso dei dati errati per la modifica dell'ambiente.
 
+
+
+
+== UC-4 Creazione scaffale
+$bold("Descrizione: ")$ 
+uno scaffale viene creato in base ai valori dati e aggiunto nell'ambiente.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+l'ambiente deve essere stato configurato.
+
+$bold("Postcondizioni: ")$
+nell'ambiente è stato aggiunto un nuovo scaffale.
+
+$bold("Scenario: ")$
+- l'utente seleziona l'aggiunta di uno scaffale;
+- l'utente inserisce i dati necessari alla creazione di uno scaffale;
+- l'utente posiziona lo scaffale in una posiziona valida nell'ambiente.

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -68,3 +68,20 @@ Questo documento viene redatto in modo incrementale, così da risultare sempre c
 - Analisi e descrizione delle funzionalità, Use Case e relativi diagrammi (UML): \
   _#link("https://www.math.unipd.it/~rcardin/swea/2022/Diagrammi%20Use%20Case.pdf")_ .
 
+
+==== UC-1.1.1 Visualizzazione errore lettura del file SVG dovuto a estensione del file sbagliata
+$bold("Descrizione: ")$
+il file per la configurazione dell'ambiente caricato ha un'estensione inattesa.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+- é stato caricato un file per la configurazione dell'ambiente;
+- il programma non ha potuto leggere tale file a causa dell'incongruenza della sua estensione.
+
+$bold("Postcondizioni: ")$
+viene visualizzato l'errore relativo al caricamento di un file con estensione diversa da SVG.
+
+$bold("Scenario: ")$
+L'utente ha caricato un file per la configurazione dell'ambiente con estensione errata.

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -1,4 +1,4 @@
-#import "template.typ":*
+#import "/template.typ":*
 
 #show: project.with(
   title:"Analisi dei Requisiti",

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -106,3 +106,23 @@ viene visualizzato l'errore relativo al caricamento di un file SVG privo di info
 $bold("Scenario: ")$
 L'utente ha caricato un file SVG vuoto o con informazioni non utili.
 
+
+
+
+==== UC-1.1.3 Visualizzazione errore lettura del file SVG dovuto a informazioni fornite incongruenti
+$bold("Descrizione: ")$
+il file SVG caricato contiene informazioni incongruenti e quindi non utilizzabili per la configurazione dell'ambiente.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+- é stato caricato un file per la configurazione dell'ambiente;
+- tale file è stato aperto correttamente dal programma;
+- il programma ha ricavato informazioni non valide dal file.
+
+$bold("Postcondizioni: ")$
+viene visualizzato l'errore relativo al caricamento di un file con informazioni incongruenti.
+
+$bold("Scenario: ")$
+L'utente ha caricato un file per la configurazione dell'ambiente contenente informazioni incongruenti.

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -254,3 +254,24 @@ $bold("Scenario: ")$
 
 $bold("Estensioni: ")$
 UC-5.1 Visualizzazione errore inserimento valori errati per la modifica di uno scaffale.
+
+
+
+=== UC-5.1 Visualizzazione errore inserimento valori errati per la modifica di uno scaffale 
+$bold("Descrizione: ")$ 
+i dati inseriti per la modifica di uno scaffale sono errati e non possono essere accettati.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+-l'attività di modifica di uno scaffale deve essere stata attivata;
+-l'inserimento dei valori per la modifica deve essere avvenuto.
+
+$bold("Postcondizioni: ")$
+viene visualizzato il messaggio di errore relativo ai dati errati.
+
+$bold("Scenario: ")$
+- l'utente ha avviato la procedura di modifica di uno scaffale esistente;
+- l'utente ha immesso dati non validi o che comporterebbero incongruenze con i bin o altri elementi dell'ambiente.
+

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -85,3 +85,24 @@ viene visualizzato l'errore relativo al caricamento di un file con estensione di
 
 $bold("Scenario: ")$
 L'utente ha caricato un file per la configurazione dell'ambiente con estensione errata.
+
+
+
+==== UC-1.1.2 Visualizzazione errore lettura del file SVG dovuto a file privo di informazioni
+$bold("Descrizione: ")$
+il file SVG caricato non contiene informazioni utili alla configurazione dell'ambiente.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+- é stato caricato un file per la configurazione dell'ambiente;
+- tale file è stato aperto correttamente dal programma;
+- il programma non ha potuto ottenere informazioni dal file.
+
+$bold("Postcondizioni: ")$
+viene visualizzato l'errore relativo al caricamento di un file SVG privo di informazioni.
+
+$bold("Scenario: ")$
+L'utente ha caricato un file SVG vuoto o con informazioni non utili.
+

--- a/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
+++ b/2 - RTB/Documentazione esterna/Analisi dei Requisiti/Analisi dei Requisiti.typ
@@ -126,3 +126,25 @@ viene visualizzato l'errore relativo al caricamento di un file con informazioni 
 
 $bold("Scenario: ")$
 L'utente ha caricato un file per la configurazione dell'ambiente contenente informazioni incongruenti.
+
+
+
+== UC-2 Configurazione ambiente 3d manuale
+$bold("Descrizione: ")$
+configurazione manuale del perimetro dell'ambiente di lavoro.
+
+$bold("Attore: ")$
+utente.
+
+$bold("Precondizioni: ")$
+è stato dato inizio alla procedura di configurazione manuale dell'ambiente di lavoro.
+
+$bold("Postcondizioni: ")$
+- la forma e il perimetro dell'ambiente di lavoro è stato configurato manualmente;
+- l'ambiente così generato ha rimosso eventuali elementi precedentemente configurati.
+
+$bold("Scenario: ")$
+l'utente inserisce i dati relativi alla configurazione.
+
+$bold("Estensioni: ")$
+UC 2.1 Visualizzazione errore sui dati.


### PR DESCRIPTION
Link alla issue di Jira: https://error418swe.atlassian.net/browse/DOC-97?atlOrigin=eyJpIjoiMDdkMDhkNzBlODU5NDFmZTlkMzI5M2M3NDQ1M2E5MmMiLCJwIjoiaiJ9

Note: sono molti commit quindi non mi stupisco se ci saranno molte conversation che nasceranno da questa pr (anche perchè è la prima che introduce gli UC), occhio alle numerazioni dei titoli typst che in questa pr non vanno bene ma solo perchè il contenuto aggiunto è da mettere dopo agli UC 1 e UC 1.1 e nella pr che aggiungeva l'UC1 c'era il comando "#set heading(numbering: none)".
Buon lavoro

### ✏️ Checklist

- [x] documento testato;
- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.