### PR TITLE
DOC-174 Gestione dello stato di log vuoto

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -48,6 +48,20 @@ show heading.where(
   it
   v(1em, weak: true)
 }
+show heading.where(
+  level: 2
+): it => {
+  v(0.5em, weak: false)
+  it
+  v(1em, weak: true)
+}
+show heading.where(
+  level: 3
+): it => {
+  it
+  v(1em, weak: true)
+}
+
 show outline.entry.where(
   level: 1
 ): it => {
@@ -238,7 +252,7 @@ page(numbering: none)[
   #let summaryHeading = align.with(right)
   #let summaryContent = align.with(left)
 
-  // Show document info
+  // Show roles
   #grid(
     columns: (25%, 25%),
     gutter: 15pt,

--- a/template.typ
+++ b/template.typ
@@ -53,6 +53,9 @@ show outline.entry.where(
 ): it => {
   strong(it)
 }
+show "WIP": it => [
+  #text(it, fill: red)
+]
 
 // Define constants
 let groupName = "Error_418"
@@ -75,6 +78,7 @@ let missingMembers = missingMembers
 let externalParticipants = externalParticipants
 let authors = authors
 let isExternalUse = isExternalUse or externalParticipants.len() > 0
+let documentVersion = "WIP"
 
 // Check members validity
 for author in authors {
@@ -106,6 +110,11 @@ if docType == "verbale" {
     }
 }
 
+// Define version
+if (changelogData.flatten().len() > 0) {
+  documentVersion = changelogData.flatten().at(0)
+}
+
 // Set the document's basic properties
 set document(
   author: "Error_418",
@@ -127,7 +136,7 @@ set page(
     text(
       0.75em,
       if counter(page).at(loc).first() > 1 [
-        #upper(title) v#changelogData.flatten().at(0)
+        #upper(title) v#documentVersion
         #h(1fr)
         #groupName
         #line(length: 100%, stroke: 0.25pt)
@@ -229,14 +238,14 @@ page(numbering: none)[
   #let summaryHeading = align.with(right)
   #let summaryContent = align.with(left)
 
-  // Show roles
+  // Show document info
   #grid(
     columns: (25%, 25%),
     gutter: 15pt,
     // Versione
     summaryHeading[*Versione*],
     summaryContent[
-      #changelogData.flatten().at(0)
+      #documentVersion
     ],
 
     // Destinazione d'uso


### PR DESCRIPTION
Link alla issue di Jira: https://error418swe.atlassian.net/browse/DOC-174?atlOrigin=eyJpIjoiNzU0MWVjZDEyNjcyNDI3Mzg1OGQyZmFkYjRjYTUzYzIiLCJwIjoiaiJ9

Situazione: i documenti appena introdotti in PR sono abbinati ad un file di changelog vuoto creato dalle GHA. Il template si aspetta che sia presente almeno il numero di versione.

Problema: il template non compila.

Soluzione:
- il template gestisce il caso di log vuoto;
- se il log è vuoto (e quindi non c'è numero di versione), il documento riporta la dicitura "WIP" in rosso al posto del numero di versione.