### PR TITLE
DOC-264 Evidenziazione riferimenti assenti o TODO

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -71,6 +71,13 @@ show outline.entry.where(
 show "WIP": it => [
   #text(it, fill: red)
 ]
+show "TODO": it => [
+  #box(
+    stroke: red,
+    inset: 0.15em,
+    text("Riferimento assente", fill: red, weight: "bold")
+  )
+]
 
 // Define constants
 let groupName = "Error_418"


### PR DESCRIPTION
### Note

D'ora in avanti sarà possibile inserire riferimenti assenti scrivendo "TODO" in qualsiasi punto del documento.
Utile durante la redazione delle Norme di Progetto.

### Checklist

- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
