### PR TITLE
DOC-265 Predisposizione per indici delle tabelle e delle immagini

### DIFF
--- a/quickstart.txt
+++ b/quickstart.txt
@@ -16,6 +16,8 @@ let timeStart: string
 let timeEnd: string
 let showLog: ?boolean = false
 let showIndex: ?boolean = true
+let showImagesIndex: ?boolean = true
+let showTablesIndex: ?boolean = true
 let isExternalUse: ?boolean = false
 ```
 

--- a/template.typ
+++ b/template.typ
@@ -12,6 +12,7 @@
   timeEnd: "",
   showLog: false,
   showIndex: true,
+  showTablesIndex: true,
   isExternalUse: false,
   body
 ) = {
@@ -89,6 +90,7 @@ let timeStart = timeStart
 let timeEnd = timeEnd
 let showLog = showLog
 let showIndex = showIndex
+let showTablesIndex = showTablesIndex
 let missingMembers = missingMembers
 let externalParticipants = externalParticipants
 let authors = authors
@@ -362,13 +364,23 @@ if (showLog and docType != "verbale") {
   pagebreak()
 }
 
-// Table of contents
+// Index of contents
 if showIndex and docType != "verbale" {
   page(numbering: none)[
     #outline(
       title: "Indice dei contenuti",
       depth: 3,
       indent: true
+    )
+  ]
+  pagebreak()
+}
+// Index of tables
+if showTablesIndex and docType != "verbale" {
+  page(numbering: none)[
+    #outline(
+      title: "Indice delle tabelle",
+      target: figure.where(kind: table)
     )
   ]
   pagebreak()

--- a/template.typ
+++ b/template.typ
@@ -12,6 +12,7 @@
   timeEnd: "",
   showLog: false,
   showIndex: true,
+  showImagesIndex: true,
   showTablesIndex: true,
   isExternalUse: false,
   body
@@ -90,6 +91,7 @@ let timeStart = timeStart
 let timeEnd = timeEnd
 let showLog = showLog
 let showIndex = showIndex
+let showImagesIndex = showImagesIndex
 let showTablesIndex = showTablesIndex
 let missingMembers = missingMembers
 let externalParticipants = externalParticipants
@@ -371,6 +373,16 @@ if showIndex and docType != "verbale" {
       title: "Indice dei contenuti",
       depth: 3,
       indent: true
+    )
+  ]
+  pagebreak()
+}
+// Index of images
+if showImagesIndex and docType != "verbale" {
+  page(numbering: none)[
+    #outline(
+      title: "Indice delle immagini",
+      target: figure.where(kind: image)
     )
   ]
   pagebreak()


### PR DESCRIPTION
### Note

- Definito indice delle tabelle
- Definito indice delle immagini
- Aggiornata lista dei parametri

La funzionalità è gestibile tramite due flag: `showImagesIndex` e `showTablesIndex`.

### Checklist

- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
