### PR TITLE
DOC-362 Correzione dipendenze Python per parse_frontmatter.yml

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install csv2md
         run: pip install csv2md
       - name: Extract info from preamble


### PR DESCRIPTION
### Note

Tentativo di correzione facendo bump da Python 3.10 a 3.12 (stessa versione dell'ambiente locale di test).

### Checklist

- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
