### PR TITLE
Assottigliati i bordi delle tabelle

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -41,7 +41,8 @@ set enum(
   numbering: "1a)",
 )
 set table(
-  fill: (_, row) => if row == 0 { luma(240) },
+  fill: (_, row) => if row == 0 { luma(220) },
+  stroke: 0.5pt + luma(140),
 )
 show link: set text(fill: blue)
 show heading.where(


### PR DESCRIPTION
### Note

Assottigliati i bordi delle tabelle per migliorare resa estetica documenti.

**Before**:
![Screenshot_20240118_170053](https://github.com/Error-418-SWE/Documenti/assets/2914344/f0ae8ca3-5206-45f5-9e91-d6492cdd4626)

**After**:
![Screenshot_20240118_170039](https://github.com/Error-418-SWE/Documenti/assets/2914344/fa0915a8-498f-44a5-a686-95cdcbf0defe)

### Checklist

- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
