### PR TITLE
DOC-479 Definizione .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.{typ, yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
### Note

Comportamento di default:
- indent: tab
- eof: trim dell'ultima riga vuota

Comportamento per file Typst o YML:
- indent: 2 spazi

### Checklist

- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
