### PR TITLE
DOC-489 Includere il contenuto della Analisi dei Rischi

### DIFF
--- a/3 - PB/Documentazione esterna/Piano di Progetto/Piano di Progetto.typ
+++ b/3 - PB/Documentazione esterna/Piano di Progetto/Piano di Progetto.typ
@@ -119,12 +119,11 @@
 == Scopo del documento
 Il documento _Piano di progetto_ ha il compito di governare la pianificazione dell'avanzamento del progetto, determinando task e obiettivi da raggiungere e presentando un'analisi critica del lavoro fino a quel momento svolto. L'intento è rendicontare e valutare criticamente l'operato compiuto per  migliorarlo, ove necessario, e gestire in modo efficace ed efficiente le risorse.
 
-Il documento si articola in 5 sezioni principali:
-- *Panoramica generale*: dedicata all'analisi preventiva dei costi complessivi di realizzazione;
-- *Periodi di sviluppo*: dedicata all'analisi della suddivisione temporale dello sviluppo del progetto;
-- *Pianificazione del lavoro*: dedicata alla descrizione della metodologia di lavoro adottata;
-- *Preventivi di periodo*: dedicata alla pianificazione delle attività da svolgere per ciascuno sprint;
-- *Consuntivi di periodo*: dedicata all'analisi retrospettiva del lavoro svolto in ciascuno sprint. Riporta eventuali criticità ed azioni intraprese a fini migliorativi.
+- *Panoramica generale* (@panoramica-generale): dedicata all'analisi preventiva dei costi complessivi di realizzazione;
+- *Periodi di sviluppo* (@periodi-di-sviluppo): dedicata all'analisi della suddivisione temporale dello sviluppo del progetto;
+- *Pianificazione del lavoro* (@pianificazione-lavoro): dedicata alla descrizione della metodologia di lavoro adottata;
+- *Preventivi di periodo* (@preventivi): dedicata alla pianificazione delle attività da svolgere per ciascuno sprint;
+- *Consuntivi di periodo* (@consuntivi): dedicata all'analisi retrospettiva del lavoro svolto in ciascuno sprint. Riporta eventuali criticità ed azioni intraprese a fini migliorativi.
 
 == Glossario
 #glo_paragrafo
@@ -160,8 +159,7 @@ Il documento si articola in 5 sezioni principali:
 
 #pagebreak()
 
-
-= Panoramica generale
+= Panoramica generale <panoramica-generale>
 Identificati i rischi, le relative contromisure e il calendario di progetto, è stato definito, mediante una pianificazione a ritroso, un preventivo iniziale dei costi di realizzazione del progetto.
 
 È corretto evidenziare come i membri del gruppo non siano dotati di esperienza sufficiente per fornire un preventivo corretto e preciso sin dagli inizi dello sviluppo: per tale motivo, il prezzo indicato sarà soggetto a modifiche con l'avanzamento del progetto (seppur mai superando il prezzo preventivato in candidatura).
@@ -239,7 +237,7 @@ Il Verificatore è un ruolo presente durante l'intero progetto, che si occupa di
 
 #pagebreak()
 
-= Periodi di sviluppo
+= Periodi di sviluppo <periodi-di-sviluppo>
 == Introduzione
 Il periodo compreso tra l'aggiudicazione del capitolato e la data di consegna del prodotto viene suddiviso in 2 periodi principali dettati dalle revisioni esterne _Requirements and Technology Baseline (RTB)_ e _Product Baseline (PB)_, rispettivamente previste per il 27-01-2024 e il 20-03-2024.\
 Vengono pertanto a definirsi i seguenti periodi di sviluppo:
@@ -395,7 +393,7 @@ data)}
 
 #pagebreak()
 
-= Pianificazione del lavoro
+= Pianificazione del lavoro <pianificazione-lavoro>
 == Introduzione
 La pianificazione ricopre un ruolo fondamentale nello sviluppo dell'intero progetto. Svolge il compito di stabilire quali obiettivi raggiungere in periodi di tempo determinati, organizzando le risorse in modo da rendere lo sviluppo efficace ed efficiente. Lo scopo principale deve essere pianificare le azioni da intraprendere nel periodo successivo, definendo tempistiche, modalità e obiettivi.
 

--- a/3 - PB/Documentazione esterna/Piano di Progetto/Piano di Progetto.typ
+++ b/3 - PB/Documentazione esterna/Piano di Progetto/Piano di Progetto.typ
@@ -209,7 +209,7 @@ In caso di Accettazione del rischio è importante tenere monitorata nel tempo la
 Lo sviluppo potrebbe allontanarsi dalle linee guida o dalle aspettative del Proponente, non rispettando quanto preventivato o pianificato. Tale rischio, comporterebbe dunque la produzione di un software non in linea con le richieste, conducendo a rallentamenti per analisi, progettazione e implementazione aggiuntive.
 
 
-=== "Effetto sottomarino"
+=== Irreperibilità di un membro del gruppo
 Uno o più membri cessano temporaneamente la partecipazione attiva alle attività del gruppo. È necessario evitare che la durata di queste assenze impedisca il regolare svolgimento delle attività di progetto.
 È da considerare ulteriormente grave la situazione in cui è mancata totalmente una segnalazione responsabile e preventiva di difficoltà o impedimenti da parte dei singoli membri coinvolti.
 

--- a/3 - PB/Documentazione esterna/Piano di Progetto/Piano di Progetto.typ
+++ b/3 - PB/Documentazione esterna/Piano di Progetto/Piano di Progetto.typ
@@ -137,10 +137,6 @@ Il documento si articola in 5 sezioni principali:
   _#link("https://github.com/Error-418-SWE/Documenti/blob/main/2%20-%20RTB/Glossario_v" + glo_vo + ".pdf")_
   #lastVisitedOn(13,02,2024)
 
-- Documento #ris_v: \
-  _#link("https://github.com/Error-418-SWE/Documenti/blob/main/2%20-%20RTB/Documentazione%20interna/Analisi%20dei%20Rischi_v" + ris_vo + ".pdf")_
-  #lastVisitedOn(13,02,2024)
-
 === Riferimenti normativi <riferimenti-normativi>
 
 - Regolamento di progetto: \

--- a/3 - PB/Documentazione esterna/Piano di Progetto/Piano di Progetto.typ
+++ b/3 - PB/Documentazione esterna/Piano di Progetto/Piano di Progetto.typ
@@ -119,6 +119,8 @@
 == Scopo del documento
 Il documento _Piano di progetto_ ha il compito di governare la pianificazione dell'avanzamento del progetto, determinando task e obiettivi da raggiungere e presentando un'analisi critica del lavoro fino a quel momento svolto. L'intento è rendicontare e valutare criticamente l'operato compiuto per  migliorarlo, ove necessario, e gestire in modo efficace ed efficiente le risorse.
 
+Il documento si articola in 6 sezioni principali:
+- *Analisi dei Rischi* (@analisi-rischi): dedicata all'analisi preventiva dei rischi e delle relative contromisure;
 - *Panoramica generale* (@panoramica-generale): dedicata all'analisi preventiva dei costi complessivi di realizzazione;
 - *Periodi di sviluppo* (@periodi-di-sviluppo): dedicata all'analisi della suddivisione temporale dello sviluppo del progetto;
 - *Pianificazione del lavoro* (@pianificazione-lavoro): dedicata alla descrizione della metodologia di lavoro adottata;
@@ -159,13 +161,141 @@ Il documento _Piano di progetto_ ha il compito di governare la pianificazione de
 
 #pagebreak()
 
+= Analisi dei Rischi <analisi-rischi>
+
+Questa sezione elenca e categorizza i rischi, li analizza e fornisce strumenti di monitoraggio e mitigazione.
+
+== Profili di rischio
+
+A ciascun rischio individuato si associano:
+  - informazioni descrittive sul suo contesto;
+  - impatto: può essere lieve, medio o grave. Esprime l'ordine di grandezza dell'effetto generato dall'evento;
+  - probabilità: da 1 a 5. Esprime la probabilità di verificarsi del rischio;
+  - soglie di accettazione del rischio;
+  - azioni previste in funzione delle soglie, possono includere:
+    - l'eliminazione del rischio;
+    - la riduzione della sua probabilità o gravità;
+    - l'accettazione del rischio.
+  - conseguenze relative a ciascuna delle azioni possibili, esse descrivono gli effetti collaterali a breve o medio termine che il rischio può comportare.
+
+== Rischi
+
+=== Comunicazione con il Proponente
+I contatti con il Proponente subiscono variazioni nella qualità e nella frequenza a causa di problematiche fuori dal controllo del gruppo. Questa situazione potrebbe causare un rallentamento significativo del lavoro, soprattutto durante l'analisi dei requisiti.
+
+- Impatto: grave;
+- Probabilità: 1;
+- Soglie:
+  - se il periodo critico previsto è sufficientemente breve da permettere al gruppo di continuare con un corretto avanzamento dei lavori nonostante la variazione nella comunicazione con il Proponente, si adotta l'"Accettazione del rischio" mantenendo monitorata la situazione;
+  - se il periodo critico previsto può mettere a rischio il corretto avanzamento dei lavori o la qualità degli stessi, si adotta l'azione correttiva di rischio: "Riduzione della sua probabilità o gravità".
+
+==== Opzioni di trattamento del rischio
+===== Riduzione della sua probabilità o gravità
+*Strategia di trattamento* \
+Si possono adottare, in accordo con il Proponente, una o più tra le seguenti strategie comunicative:
+  - uso di strumenti asincroni per facilitare lo scambio di informazioni tra gruppo e Proponente;
+  - pianificazione anticipata degli incontri di revisione dell'avanzamento;
+  - programmazione di incontri periodici di aggiornamento, anche brevi.
+\ *Conseguenze* \
+È prevista una modifica sostanziale, più o meno temporanea, nella comunicazione con il Proponente. Questo potrebbe portare a ritardi nei lavori dovuti ad un maggior impegno da parte del gruppo nel garantire l'adozione delle nuove pratiche.
+
+===== Accettazione del rischio
+*Strategia di trattamento* \
+Si attende il termine del periodo nel quale la comunicazione con il Proponente risulta problematica.
+Per evitare perdite di tempo il gruppo continua a lavorare priorizzando task che non dipendono direttamente dall'intervento del Proponente.
+In caso di Accettazione del rischio è importante tenere monitorata nel tempo la situazione per accertarsi che le circostanze non richiedano una modifica nell'approccio di risoluzione.
+
+\ *Conseguenze* \
+Lo sviluppo potrebbe allontanarsi dalle linee guida o dalle aspettative del Proponente, non rispettando quanto preventivato o pianificato. Tale rischio, comporterebbe dunque la produzione di un software non in linea con le richieste, conducendo a rallentamenti per analisi, progettazione e implementazione aggiuntive.
+
+
+=== "Effetto sottomarino"
+Uno o più membri cessano temporaneamente la partecipazione attiva alle attività del gruppo. È necessario evitare che la durata di queste assenze impedisca il regolare svolgimento delle attività di progetto.
+È da considerare ulteriormente grave la situazione in cui è mancata totalmente una segnalazione responsabile e preventiva di difficoltà o impedimenti da parte dei singoli membri coinvolti.
+
+- Impatto: medio;
+- Probabilità: 3;
+- Soglie:
+  - se la cessazione della partecipazione da parte di uno o più membri del gruppo può causare un rallentamento nell'avanzamento dei lavori è necessario discutere con i diretti interessati al fine di inquadrare al meglio la situazione. Nel caso in cui tale dialogo rivelasse un'impossibilità nella ripresa delle attività in breve termine oppure nel caso in cui non sia possibile contattare i diretti interessati, è necessario attuare la "Riduzione della sua probabilità o gravità";
+  - in caso contrario, se contattando i membri coinvolti emerge la previsione certa di una corretta ripresa delle attività in breve tempo, si attua l'"Accettazione del rischio".
+
+==== Opzioni di trattamento del rischio
+===== Riduzione della sua probabilità o gravità
+*Strategia di trattamento* \
+Le attività di lavoro assegnate ai membri coinvolti che non hanno una corretta conclusione nei tempi e nelle modalità previste possono essere riassegnate ad altri membri del gruppo.
+Viene sollecitato il dialogo con i membri coinvolti per capire la situazione e programmare al meglio le attività da svolgere.
+
+\ *Conseguenze* \
+Vengono ridotti, seppur non eliminati, i ritardi nell'avanzamento dei lavori.
+Le task svolte senza una chiara condivisione di informazioni da parte dei membri coinvolti possono portare a risultati non conformi con le decisioni prese dal gruppo di lavoro quindi possono risultare in parte o totalmente inutilizzabili.
+
+===== Accettazione del rischio
+*Strategia di trattamento* \
+Si attende il termine del periodo nel quale la partecipazione dei membri interessati risulti insufficiente.
+In caso di Accettazione del rischio è importante tenere monitorata nel tempo la situazione per accertarsi che le circostanze non richiedano una modifica nell'approccio di risoluzione.
+
+\ *Conseguenze* \
+I membri che si dovessero trovare in questa situazione rischierebbero di accentuare eventuali incomprensioni nel proprio lavoro senza la possibilità di confrontarsi con gli altri accorgendosi degli errori troppo tardi.
+Lo stato di avanzamento dei lavori potrebbe subire ulteriori rallentamenti.
+
+
+=== Rallentamento delle attività dovuto a cause esterne
+Rallentamento nel completamento di attività e task assegnate derivato dalla congiunzione tra gli impegni individuali e progettuali.
+Esso comporta un generale ritardo nello sviluppo.
+
+- Impatto: grave;
+- Probabilità: 4 _Probabilità aumentata nel periodo della sessione invernale_;
+- Soglie: se i rallentamenti previsti possono ridurre l'efficienza lavorativa del gruppo, si attua il trattamento "Riduzione della sua probabilità o gravità".
+
+==== Opzioni di trattamento del rischio
+===== Riduzione della sua probabilità o gravità
+*Strategia di trattamento* \
+Implementazione di una pianificazione più flessibile decisa in sede di meeting, per adattarsi agli impegni individuali e progettuali.
+Questo prevede una priorizzazione nell'uso di strumenti di lavoro asincroni, al fine di permettere a tutti i membri un'equa divisione del lavoro da svolgere nei momenti a loro più comodi, a patto di rispettare le linee guida delle Norme di Progetto.
+Assegnazione chiara delle responsabilità in luce dei rallentamenti previsti e monitoraggio costante dello stato di avanzamento.
+Inoltre è richiesta comunicazione costante con i membri del gruppo al fine di rendere note eventuali indisponibilità o impegni.
+
+
+\ *Conseguenze* \
+Miglioramento dell'efficienza nel completamento dei compiti nonostante i rallentamenti inevitabili.
+Le attività non svolte o completate parzialmente possono determinare uno slittamento della data di consegna e delle scadenze intermedie prefissate.
+
+
+=== Utilizzo problematico delle tecnologie
+Le tecnologie individuate o suggerite durante i processi di analisi e progettazione potrebbero risultare complesse da comprendere e/o integrare.
+
+- Impatto: medio;
+- Probabilità: 4;
+- Soglie:
+  - se, compreso un ragionevole rallentamento dovuto all'apprendimento di nuove competenze, la complessità delle tecnologie risulta gestibile con le competenze attuali del gruppo e non compromette significativamente la tempistica del progetto, si adotta l'"Accettazione del rischio";
+  - se la complessità delle tecnologie supera significativamente le competenze attuali del gruppo e potrebbe quindi causare gravi ritardi nell'avanzamento dei lavori, si adotta l'azione correttiva di rischio: "Riduzione della sua probabilità o gravità".
+
+==== Opzioni di trattamento del rischio
+===== Riduzione della sua probabilità o gravità
+*Strategia di trattamento* \
+Viene considerata in sede di meeting la necessità di individuare tecnologie sostitutive che rimpiazzeranno quelle coinvolte, esse dovranno essere studiate ed implementate al fine di soddisfare i requisiti rimasti irrisolti a causa dell'occorrenza del rischio.
+Se si ritiene necessario, si richiede una maggiore partecipazione da parte degli altri membri del gruppo, con conseguente riassegnazione di attività e/o ruoli, per integrare le nuove tecnologie nel minor tempo possibile.
+
+\ *Conseguenze* \
+Le analisi tecnologiche precedentemente svolte devono essere riviste in luce delle nuove opzioni individuate. Queste ultime possono essere a loro volta totalmente o parzialmente sconosciute al gruppo, il quale dovrà dedicare tempo, non preventivato precedentemente, alla loro comprensione ed integrazione.
+Le nuove tecnologie individuate possono potenzialmente generare nuovamente questo rischio portando ad un rallentamento grave nell'avanzamento dei lavori.
+
+===== Accettazione del rischio
+*Strategia di trattamento* \
+Il gruppo accetta la complessità delle tecnologie e si impegna a risolvere eventuali problemi nell'implementazione e utilizzo delle stesse.
+Se si ritiene necessario, si richiede una maggiore partecipazione da parte degli altri membri del gruppo, con conseguente riassegnazione di attività e/o ruoli, alla risoluzione degli eventuali problemi riscontrati.
+In caso di Accettazione del rischio è importante tenere monitorata nel tempo la situazione per accertarsi che le circostanze non richiedano una modifica nell'approccio di risoluzione.
+
+\ *Conseguenze* \
+Rallentamenti non preventivati che possono avere conseguenze a cascata sulle attività dipendenti e che possono coinvolgere più membri del gruppo per un periodo di tempo difficilmente prevedibile.
+
+
+#pagebreak()
+
 = Panoramica generale <panoramica-generale>
 Identificati i rischi, le relative contromisure e il calendario di progetto, è stato definito, mediante una pianificazione a ritroso, un preventivo iniziale dei costi di realizzazione del progetto.
 
 È corretto evidenziare come i membri del gruppo non siano dotati di esperienza sufficiente per fornire un preventivo corretto e preciso sin dagli inizi dello sviluppo: per tale motivo, il prezzo indicato sarà soggetto a modifiche con l'avanzamento del progetto (seppur mai superando il prezzo preventivato in candidatura).
-
-== Rischi e loro mitigazione
-Il documento Analisi dei Rischi (v2.0.0), riportato in @riferimenti-interni, elenca e categorizza i rischi, li analizza e fornisce strumenti di monitoraggio e mitigazione.
 
 == Prospetto orario complessivo <prospetto-orario-complessivo>
 La ripartizione delle ore tiene conto degli obiettivi disciplinari di sviluppo di competenze trasversali nei vari ruoli presenti all'interno del progetto.

--- a/3 - PB/Documentazione esterna/Piano di Progetto/log.csv
+++ b/3 - PB/Documentazione esterna/Piano di Progetto/log.csv
@@ -1,3 +1,4 @@
+1.9.0,18-02-2024,296,DOC-489 Includere il contenuto della Analisi dei Rischi,Gardin Giovanni,Carraro Riccardo
 1.8.0,16-02-2024,278,DOC-477 Redigere preventivo di periodo Sprint 15,Gardin Giovanni,Carraro Riccardo
 1.7.0,14-02-2024,270,DOC-476 Redigere consuntivo di periodo sprint 14,Gardin Giovanni,Carraro Riccardo
 1.6.0,14-02-2024,270,DOC-476 Redigere consuntivo di periodo sprint 14,Gardin Giovanni,Carraro Riccardo


### PR DESCRIPTION
### Note

Il documento è stato incorporato. La sezione ha bisogno di essere rivista secondo quanto previsto dalla [DOC-492].

- Rimosso riferimento Analisi dei Rischi (chiude [DOC-495])
- Aggiunti riferimenti alle sezioni
- Incorporata Analisi dei Rischi
- Rinominato rischio "effetto sottomarino"

### Checklist

- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.


[DOC-492]: https://error418swe.atlassian.net/browse/DOC-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOC-495]: https://error418swe.atlassian.net/browse/DOC-495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ