### PR TITLE
DOC-488 Specificare l'affiliazione dei partecipanti ad un meeting

### DIFF
--- a/common.typ
+++ b/common.typ
@@ -42,6 +42,8 @@
 
 #let grafana = "https://error418swe.grafana.net/public-dashboards/9392efccc5a5427c850fc9ec81df7dff"
 
+#let azienda = "Sanmarco Informatica S.p.A."
+
 #let lastVisitedOn(day, month, year) = {
   if (year < 99) { year += 2000 }
   text("(ultimo accesso " + datetime(year: year, month: month, day: day).display("[day]/[month]/[year]") + ")", size: 0.8em, style: "italic", fill: luma(100))

--- a/log.csv
+++ b/log.csv
@@ -1,1 +1,2 @@
+0.1.0,21-02-2024,315,DOC-488 Specificare l'affiliazione dei partecipanti ad un meeting),Gardin Giovanni,Carraro Riccardo
 0.0.1,18-02-2024,1,DOC-# Riga di changelog di esempio,Ian Sommerville,William Edwards Deming

--- a/template.typ
+++ b/template.typ
@@ -156,7 +156,7 @@ set document(
 // Insert company to recipients list
 for externalParticipant in externalParticipants {
   if externalParticipant.role.contains("Referente aziendale") {
-    recipients.insert(1, "Sanmarco Informatica")
+    recipients.insert(1, azienda)
     break
   }
 }

--- a/template.typ
+++ b/template.typ
@@ -445,7 +445,7 @@ if docType == "verbale" [
     }
   }
   #for other in externalParticipants {
-    allParticipants.insert(0, other.name)
+    allParticipants.insert(0, other.name + " (" + other.role + ")")
   }
 
   = Informazioni generali

--- a/template.typ
+++ b/template.typ
@@ -445,7 +445,7 @@ if docType == "verbale" [
     }
   }
   #for other in externalParticipants {
-    allParticipants.insert(0, other.name + " (" + other.role + ")")
+    allParticipants.insert(0, other.name + " (" + other.role + ", " + azienda + ")")
   }
 
   = Informazioni generali


### PR DESCRIPTION
### Note

Aggiornamento ai file di supporto per mostrare l'ente di affiliazione nei verbali esterni.

- Specificata affiliazione dei partecipanti esterni nei verbali
- Definita variabile per richiamare la ragione sociale dell'azienda

### Checklist

- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
