### PR TITLE
DOC-535 Correggere errore di registrazione versione

### DIFF
--- a/.github/workflows/log_changes.yml
+++ b/.github/workflows/log_changes.yml
@@ -72,3 +72,12 @@ jobs:
           git add "${{ needs.fetch.outputs.file_path }}/log.csv"
           git commit -m "Aggiunti dettagli di rilascio"
           git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
+  register:
+    name: Register new version
+    if: github.event.review.state == 'approved' && needs.fetch.outputs.file_name != ''
+    needs: [fetch, version]
+    uses: Error-418-SWE/Documenti/.github/workflows/register_version.yml@src
+    with:
+      file_name: ${{ needs.fetch.outputs.file_name }}
+      file_version: ${{ needs.version.outputs.next_version }}

--- a/.github/workflows/register_version.yml
+++ b/.github/workflows/register_version.yml
@@ -22,6 +22,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
           git fetch
+          git checkout ${{ github.event.pull_request.head.ref }}
       - name: Insert new version
         run: |
           sed -i "s/\"${{ inputs.file_name }}\": \".*\"/\"${{ inputs.file_name }}\": \"${{ inputs.file_version }}\"/" "documents.json"
@@ -29,4 +30,4 @@ jobs:
         run: |
           git add documents.json
           git commit -am "Aggiornata versione ${{ inputs.file_name }}"
-          git push origin src
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/release_typst.yml
+++ b/.github/workflows/release_typst.yml
@@ -111,11 +111,3 @@ jobs:
           git add "${{ steps.publish_path.outputs.PUBLISH_PATH }}/${{ needs.fetch.outputs.file_name }}*.pdf"
           git commit -am "Publish document ${{ needs.fetch.outputs.file_name }} (v${{ needs.fetch.outputs.current_version }})"
           git push origin $TARGET_BRANCH
-
-  register:
-    if: github.event.pull_request.merged == true
-    needs: [fetch, publish]
-    uses: Error-418-SWE/Documenti/.github/workflows/register_version.yml@src
-    with:
-      file_name: ${{ needs.fetch.outputs.file_name }}
-      file_version: ${{ needs.fetch.outputs.current_version }}

--- a/.github/workflows/release_typst_log.yml
+++ b/.github/workflows/release_typst_log.yml
@@ -70,11 +70,3 @@ jobs:
           git add "${{ steps.publish_path.outputs.PUBLISH_PATH }}/${{ needs.fetch.outputs.file_name }}*.pdf"
           git commit -am "Publish document ${{ needs.fetch.outputs.file_name }} (v${{ needs.fetch.outputs.current_version }})"
           git push origin $TARGET_BRANCH
-
-  register:
-    if: github.event.pull_request.merged == true
-    needs: [fetch, publish]
-    uses: Error-418-SWE/Documenti/.github/workflows/register_version.yml@src
-    with:
-      file_name: ${{ needs.fetch.outputs.file_name }}
-      file_version: ${{ needs.fetch.outputs.current_version }}


### PR DESCRIPTION
### Note

Le versioni globali dei documenti non venivano salvate perché il file veniva modificato su `src`. Ora l'aggiornamento viene fatto contestualmente all'aggiornamento del log.

- Rimossa chiamata a workflow
- Aggiornato workflow per modifica tramite PR
- Aggiunta chiamata

### Checklist

- [x] titolo della PR conforme;
- [x] designato almeno un verificatore.
